### PR TITLE
Fix watch command on windows

### DIFF
--- a/ivy/cli/watch.py
+++ b/ivy/cli/watch.py
@@ -69,11 +69,14 @@ def callback(parser):
     # 1. Directly, as `python3 /path/to/ivy/package`.
     # 2. As an installed package on the import path, `python3 -m ivy`.
     # 3. Via an entry script, `ivy`.
+    # 4. Via windows executable `ivy.exe`
     if os.path.isdir(sys.argv[0]):
         base += ['python3', sys.argv[0]]
     elif os.path.isfile(sys.argv[0]) and sys.argv[0].endswith('__main__.py'):
         base += ['python3', sys.argv[0]]
     elif os.path.isfile(sys.argv[0]):
+        base.append(sys.argv[0])
+    elif os.name == 'nt' and os.path.isfile(sys.argv[0] + '.exe'):
         base.append(sys.argv[0])
 
     # Append the 'build' command, a 'watching' flag, and any user arguments.


### PR DESCRIPTION
Fix watch command unable to find ivy executable on windows platform due to file extension